### PR TITLE
Host seperate docs for stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Also you'll need `ldoc` if you want to build the docs and `penlight` to run the 
 
 ## Documentation
 
-Available online [here](http://darkstalker.github.io/LuaTwit/).
+Available online [here](http://darkstalker.github.io/LuaTwit/master).
 
 ## Installation
 

--- a/gen_docs.sh
+++ b/gen_docs.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+STATUS=$(git status --porcelain)
+DOC_TMP=$(mktemp -d)
+
+function generate_docs {
+  git checkout "$1"
+  ldoc -d "$DOC_TMP/$1" .
+}
+
+mkdir -p "$DOC_TMP"
+
+if [ -n "$STATUS" ]; then
+  echo "Git directory not clean"
+  echo "Aborting..."
+  exit 1
+else
+  CUR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  for tag in "master" $(git tag); do
+    generate_docs "$tag"
+  done
+  git checkout "gh-pages"
+  rm -rf *
+  mv "$DOC_TMP"/* .
+  git add .
+  git commit
+  git checkout "$CUR_BRANCH"
+fi
+
+rm -rf "$DOC_TMP"


### PR DESCRIPTION
Hi,

I was caught rather off-guard when I tried to use an example which I had used yesterday, but commits in the last 24 hours caused incompatibilities as the example from the documentation pages had been updated (rightly so) for a newer version of the API of this module.

I can't help but feel that it would be nice if it was easier to browse documentation relevant to the stable (i.e. tagged and released) version of this module.

A workaround would be to clone the gh-pages branch at the relevant commit I suppose.
